### PR TITLE
cutted content-type value

### DIFF
--- a/Serializer/Serializer.php
+++ b/Serializer/Serializer.php
@@ -106,6 +106,8 @@ class Serializer {
 	 */
 	public function deserialize(Request $request, $objectClass) {
 		$contentType = $request->headers->get('content-type');
+		$contentType = substr($contentType, 0, strpos($contentType, ";"));
+
 		if ($this->isDeserializationTypeSupported($contentType)) {
 			$type = $this->supportedDeserializationTypes[$contentType];
 			return $this->serializer->deserialize($request->getContent(), $objectClass, $type);

--- a/Serializer/Serializer.php
+++ b/Serializer/Serializer.php
@@ -106,7 +106,9 @@ class Serializer {
 	 */
 	public function deserialize(Request $request, $objectClass) {
 		$contentType = $request->headers->get('content-type');
-		$contentType = substr($contentType, 0, strpos($contentType, ";"));
+		if (strpos($contentType, ";") !== false) {
+			$contentType = substr($contentType, 0, strpos($contentType, ";"));
+		}
 
 		if ($this->isDeserializationTypeSupported($contentType)) {
 			$type = $this->supportedDeserializationTypes[$contentType];


### PR DESCRIPTION
requests sent from firefox are enriched with Content-type header contains value after semicolon
